### PR TITLE
chore(dependabot): add 3-day cooldown for supply-chain safety

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,8 @@ version: 2
 updates:
   # npm パッケージの更新設定
   - package-ecosystem: "npm"
+    cooldown:
+      default-days: 3
     directory: "/"
     schedule:
       interval: "weekly"
@@ -57,6 +59,8 @@ updates:
 
   # GitHub Actionsの更新設定
   - package-ecosystem: "github-actions"
+    cooldown:
+      default-days: 3
     directory: "/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
## 概要
サプライチェーン攻撃のリスク低減のため、Dependabot に **3日間の cooldown** を設定します。新しく公開された依存バージョンへの更新 PR を 3 日間遅延させ、公開直後の悪意あるバージョンを取り込みにくくします。

## 変更内容
- 各 `updates` エントリに `cooldown.default-days: 3` を追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)