### PR TITLE
fix: remove unexpected value from actions workflow yml

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -8,7 +8,6 @@ on:
 permissions:
   contents: write
   pull-requests: write
-  workflows: write
 
 jobs:
   dependabot:


### PR DESCRIPTION
close #95 

We want to permit to auto-merge, but misunderstood it need the 'workflow' scope permission.
GitHub Actions workflow doesn't have a syntax of 'workflows'.
ref. https://docs.github.com/ja/actions/reference/workflows-and-actions/workflow-syntax#permissions

We already have enough permissions for auto-merge, so I removed it.

BTW: That is provided for permit scope for PAT/OAuth token settings.
ref. https://docs.github.com/ja/apps/oauth-apps/building-oauth-apps/scopes-for-oauth-apps#available-scopes